### PR TITLE
Update weather widget & station links

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,15 +50,6 @@
       <a href="contact.html"> contact the board </a> to get involved.
       All Quail Creek neighbors (HOA and non-HOA) are welcome and encouraged to take an active role in enhancing 
       the beauty and warmth of our community!
-       
-      <!-- Weather Widget -->
-      <div class="wx-widget">
-        <a href="http://www.wunderground.com/weatherstation/WXDailyHistory.asp?ID=KWAREDMO109"
-           target='wx'>
-          <img src="http://banners.wunderground.com/cgi-bin/banner/ban/wxBanner?bannertype=pws250&weatherstationcount=KWAREDMO109"
-            width="188" height="112" border="0" alt="Weather Underground PWS KWAREDMO109">
-        </a>
-      </div>
 
     </div>
   </div>

--- a/links.html
+++ b/links.html
@@ -64,6 +64,12 @@
       <li><a href="https://nextdoor.com/groups/15667861/">Nextdoor / Quail Creek</a>
     </ul>
 
+    <h2>Miscellaneous</h2>
+    <ul>
+      <li><a href="https://www.wunderground.com/dashboard/pws/KWAREDMO240" target="qcwx">
+        Neighborhood Weather</a>
+    </ul>
+
   </div>
 
 </body>


### PR DESCRIPTION
Looks like our local weather station (which I believe is run by Andrew)
has changed its identifier, and Weather Underground no longer supports
weather widgets.

I've pulled the now non-functional weather widget from the home page,
and moved it under a new miscellaneous section on our links page.